### PR TITLE
docs: document the required permissions for the GitHub token

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ jobs:
   lint-pr:
     name: Lint pull request title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # post comments when 'comment' is true
     steps:
       - name: Lint pull request title
         uses: jef/conventional-commits-pr-action@v1
@@ -40,6 +42,8 @@ jobs:
 
 | Default value | `true` |
 |---------------|--------|
+
+**Note**: commenting in the pull request conversation requires that the token is configured with the `pull-requests` permission.
 
 ### `token`
 


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Precise the permissions required to create the Pull Request comment. This is required when the default permissions are set to `read` in the repository where the action runs.

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

I have tested the configuration in various repository with default read permissions. For instance, see https://github.com/bonitasoft/bonita-doc/blob/32b9fe9f04f7f70e7f06e1274816b9dd2febdb78/.github/workflows/contribution-check.yml#L9-L12
