### PR TITLE
feat: add bots_ignore input

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ jobs:
 
 ## Inputs
 
+### `bots_ignore`
+
+**Optional** A list of bots to ignore when linting the pull request title. Can be a comma-separated list.
+
 ### `comment`
 
 **Optional** Post a comment in the pull request conversation with examples.

--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,10 @@ branding:
   icon: align-left
   color: blue
 inputs:
+  bots_ignore:
+    required: false
+    description: A list of bots to ignore when linting the pull request title. Can be a comma-separated list.
+    default: ''
   comment:
     required: false
     description: Post a comment in the pull request conversation with examples.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
 module.exports = {
+  collectCoverage: true,
   testEnvironment: 'node',
   transform: {
     '^.+.tsx?$': ['ts-jest', {}],

--- a/src/__tests__/lint.test.ts
+++ b/src/__tests__/lint.test.ts
@@ -8,7 +8,7 @@ import {getInput} from '@actions/core';
 jest.mock('@actions/core');
 
 describe('getConvetionalCommitTypes tests', () => {
-  it('should return types', () => {
+  test('should return types', () => {
     const types = getConventionalCommitTypes();
 
     expect(
@@ -37,7 +37,7 @@ describe('lintPullRequest tests', () => {
   ];
 
   tests.forEach(({args, expected}) => {
-    it(`should pass or fail linting ['${args}', '${expected}']`, async () => {
+    test(`should pass or fail linting ['${args}', '${expected}']`, async () => {
       expect(await lintPullRequest(args)).toBe(expected);
     });
   });
@@ -50,12 +50,12 @@ jest.mock('@actions/github', () => ({
 }));
 
 describe('isBotIgnored tests', () => {
-  it('should return true if the bot is in the ignore list', () => {
+  test('should return true if the bot is in the ignore list', () => {
     (getInput as jest.Mock).mockReturnValue('test-bot,another-bot');
     expect(isBotIgnored()).toBe(true);
   });
 
-  it('should return false if the bot is not in the ignore list', () => {
+  test('should return false if the bot is not in the ignore list', () => {
     (getInput as jest.Mock).mockReturnValue('another-bot');
     expect(isBotIgnored()).toBe(false);
   });

--- a/src/__tests__/lint.test.ts
+++ b/src/__tests__/lint.test.ts
@@ -1,4 +1,11 @@
-import {getConventionalCommitTypes, lintPullRequest} from '../lint';
+import {
+  getConventionalCommitTypes,
+  lintPullRequest,
+  isBotIgnored,
+} from '../lint';
+import {getInput} from '@actions/core';
+
+jest.mock('@actions/core');
 
 describe('getConvetionalCommitTypes tests', () => {
   it('should return types', () => {
@@ -33,5 +40,23 @@ describe('lintPullRequest tests', () => {
     it(`should pass or fail linting ['${args}', '${expected}']`, async () => {
       expect(await lintPullRequest(args)).toBe(expected);
     });
+  });
+});
+
+jest.mock('@actions/github', () => ({
+  context: {
+    actor: 'test-bot',
+  },
+}));
+
+describe('isBotIgnored tests', () => {
+  it('should return true if the bot is in the ignore list', () => {
+    (getInput as jest.Mock).mockReturnValue('test-bot,another-bot');
+    expect(isBotIgnored()).toBe(true);
+  });
+
+  it('should return false if the bot is not in the ignore list', () => {
+    (getInput as jest.Mock).mockReturnValue('another-bot');
+    expect(isBotIgnored()).toBe(false);
   });
 });

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -5,9 +5,16 @@ import {
   getPullRequest,
 } from './github';
 import * as conventionalCommitTypes from 'conventional-commit-types';
-import {getInput} from '@actions/core';
+import {getInput, info} from '@actions/core';
+import {context} from '@actions/github';
 
 const types = Object.keys(conventionalCommitTypes.types);
+
+export function isBotIgnored() {
+  const botsIgnore = getInput('bots_ignore').split(',');
+
+  return botsIgnore.includes(context.actor);
+}
 
 export function getConventionalCommitTypes(): string {
   return types
@@ -28,6 +35,11 @@ export async function lintPullRequest(title: string) {
 }
 
 export async function lint() {
+  if (isBotIgnored()) {
+    info('Bot is ignored. Skipping linting.');
+    return;
+  }
+
   const pr = await getPullRequest();
 
   const isPrTitleOk = await lintPullRequest(pr.title);

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -12,7 +12,6 @@ const types = Object.keys(conventionalCommitTypes.types);
 
 export function isBotIgnored() {
   const botsIgnore = getInput('bots_ignore').split(',');
-
   return botsIgnore.includes(context.actor);
 }
 
@@ -41,7 +40,6 @@ export async function lint() {
   }
 
   const pr = await getPullRequest();
-
   const isPrTitleOk = await lintPullRequest(pr.title);
 
   if (isPrTitleOk) {


### PR DESCRIPTION
### Description

Add `bots_ignore` to inputs so users can potentially ignore bot PRs on linting.